### PR TITLE
Entrega das funcionalidades desenvolvidas no Ciclo 6

### DIFF
--- a/src/config/locales/models/bidding.en-US.yml
+++ b/src/config/locales/models/bidding.en-US.yml
@@ -20,6 +20,7 @@
         address: Delivery location
         cancel_comment: reason for cancellation
         classification_name: Classification
+        subclassifications: Subclassifications
         modality: Modality
         draw_end_days: Calendar days for tie-break
 

--- a/src/config/locales/models/bidding.en-US.yml
+++ b/src/config/locales/models/bidding.en-US.yml
@@ -18,6 +18,10 @@
         covenantId: Covenant
         covenant: Covenant
         address: Delivery location
+        cancel_comment: reason for cancellation
+        classification_name: Classification
+        modality: Modality
+        draw_end_days: Calendar days for tie-break
 
         statuses:
           all: -- List All --
@@ -39,6 +43,11 @@
           global: Global price
           lot: Price per lot
           unitary: Unit price
+
+        modalities:
+          unrestricted: Open/Public
+          open_invite: Open call for bids
+          closed_invite: Closed call for bids
 
       errors:
         covenant:

--- a/src/config/locales/models/bidding.en-US.yml
+++ b/src/config/locales/models/bidding.en-US.yml
@@ -19,6 +19,9 @@
         covenant: Covenant
         address: Delivery location
         cancel_comment: reason for cancellation
+        classification_name: Classification
+        modality: Modality
+        draw_end_days: Calendar days for tie-break
 
         statuses:
           all: -- List All --
@@ -40,6 +43,11 @@
           global: Global price
           lot: Price per lot
           unitary: Unit price
+
+        modalities:
+          unrestricted: Open/Public
+          open_invite: Open call for bids
+          closed_invite: Closed call for bids
 
       errors:
         covenant:

--- a/src/config/locales/models/bidding.en-US.yml
+++ b/src/config/locales/models/bidding.en-US.yml
@@ -18,6 +18,7 @@
         covenantId: Covenant
         covenant: Covenant
         address: Delivery location
+        cancel_comment: reason for cancellation
 
         statuses:
           all: -- List All --

--- a/src/config/locales/models/bidding.es-PY.yml
+++ b/src/config/locales/models/bidding.es-PY.yml
@@ -20,6 +20,7 @@
         address: Lugar de entrega
         cancel_comment: Razón de la cancelación
         classification_name: Clasificación
+        subclassifications: Subclasificaciones
         modality: Modalidad
         draw_end_days: Días corridos para desempate
 

--- a/src/config/locales/models/bidding.es-PY.yml
+++ b/src/config/locales/models/bidding.es-PY.yml
@@ -18,6 +18,7 @@
         covenantId: Convenio
         covenant: Convenio
         address: Lugar de entrega
+        cancel_comment: Razón de la cancelación
 
         statuses:
           all: -- Listar Todo --

--- a/src/config/locales/models/bidding.es-PY.yml
+++ b/src/config/locales/models/bidding.es-PY.yml
@@ -19,6 +19,9 @@
         covenant: Convenio
         address: Lugar de entrega
         cancel_comment: Razón de la cancelación
+        classification_name: Clasificación
+        modality: Modalidad
+        draw_end_days: Días corridos para desempate
 
         statuses:
           all: -- Listar Todo --
@@ -40,6 +43,11 @@
           global: Precio global
           lot: Precio por lote
           unitary: Precio individual
+
+        modalities:
+          unrestricted: Abierta/Pública
+          open_invite: Invitación abierta
+          closed_invite: Invitación cerrada
 
       errors:
         covenant:

--- a/src/config/locales/models/bidding.es-PY.yml
+++ b/src/config/locales/models/bidding.es-PY.yml
@@ -18,6 +18,10 @@
         covenantId: Convenio
         covenant: Convenio
         address: Lugar de entrega
+        cancel_comment: Razón de la cancelación
+        classification_name: Clasificación
+        modality: Modalidad
+        draw_end_days: Días corridos para desempate
 
         statuses:
           all: -- Listar Todo --
@@ -39,6 +43,11 @@
           global: Precio global
           lot: Precio por lote
           unitary: Precio individual
+
+        modalities:
+          unrestricted: Abierta/Pública
+          open_invite: Invitación abierta
+          closed_invite: Invitación cerrada
 
       errors:
         covenant:

--- a/src/config/locales/models/bidding.fr-FR.yml
+++ b/src/config/locales/models/bidding.fr-FR.yml
@@ -19,7 +19,10 @@
         covenant: Convention
         address: Lieu de livraison
         cancel_comment: Raison pour l'annulation
-        
+        classification_name: Classification
+        modality: Modalité
+        draw_end_days: Jours consécutifs pour le départage
+
         statuses:
           all: -- Tout lister --
           approved: Libérée
@@ -40,6 +43,11 @@
           global: Prix global
           lot: Prix par lot
           unitary: Prix individuel
+
+        modalities:
+          unrestricted: Ouverte/publique
+          open_invite: Invitation ouverte
+          closed_invite: Invitation fermée
 
       errors:
         covenant:

--- a/src/config/locales/models/bidding.fr-FR.yml
+++ b/src/config/locales/models/bidding.fr-FR.yml
@@ -18,7 +18,8 @@
         covenantId: Convention
         covenant: Convention
         address: Lieu de livraison
-
+        cancel_comment: Raison pour l'annulation
+        
         statuses:
           all: -- Tout lister --
           approved: Libérée

--- a/src/config/locales/models/bidding.fr-FR.yml
+++ b/src/config/locales/models/bidding.fr-FR.yml
@@ -18,6 +18,10 @@
         covenantId: Convention
         covenant: Convention
         address: Lieu de livraison
+        cancel_comment: Raison pour l'annulation
+        classification_name: Classification
+        modality: Modalité
+        draw_end_days: Jours consécutifs pour le départage
 
         statuses:
           all: -- Tout lister --
@@ -39,6 +43,11 @@
           global: Prix global
           lot: Prix par lot
           unitary: Prix individuel
+
+        modalities:
+          unrestricted: Ouverte/publique
+          open_invite: Invitation ouverte
+          closed_invite: Invitation fermée
 
       errors:
         covenant:

--- a/src/config/locales/models/bidding.fr-FR.yml
+++ b/src/config/locales/models/bidding.fr-FR.yml
@@ -20,6 +20,7 @@
         address: Lieu de livraison
         cancel_comment: Raison pour l'annulation
         classification_name: Classification
+        subclassifications: Sous-classifications
         modality: Modalité
         draw_end_days: Jours consécutifs pour le départage
 

--- a/src/config/locales/models/bidding.pt-BR.yml
+++ b/src/config/locales/models/bidding.pt-BR.yml
@@ -19,6 +19,9 @@ pt-BR:
         covenant: Convênio
         address: Local de entrega
         cancel_comment: Motivo do cancelamento
+        classification_name: Classificação
+        modality: Modalidade
+        draw_end_days: Dias corridos para desempate
 
         statuses:
           all: -- Listar Todas --
@@ -40,6 +43,11 @@ pt-BR:
           global: Preço global
           lot: Preço por lote
           unitary: Preço individual
+
+        modalities:
+          unrestricted: Aberta/Pública
+          open_invite: Convite aberto
+          closed_invite: Convite fechado
 
       errors:
         covenant:

--- a/src/config/locales/models/bidding.pt-BR.yml
+++ b/src/config/locales/models/bidding.pt-BR.yml
@@ -20,6 +20,7 @@ pt-BR:
         address: Local de entrega
         cancel_comment: Motivo do cancelamento
         classification_name: Classificação
+        subclassifications: Subclassificações
         modality: Modalidade
         draw_end_days: Dias corridos para desempate
 

--- a/src/config/locales/models/bidding.pt-BR.yml
+++ b/src/config/locales/models/bidding.pt-BR.yml
@@ -18,6 +18,7 @@ pt-BR:
         covenantId: Convênio
         covenant: Convênio
         address: Local de entrega
+        cancel_comment: Motivo do cancelamento
 
         statuses:
           all: -- Listar Todas --

--- a/src/config/locales/models/bidding.pt-BR.yml
+++ b/src/config/locales/models/bidding.pt-BR.yml
@@ -18,6 +18,10 @@ pt-BR:
         covenantId: Convênio
         covenant: Convênio
         address: Local de entrega
+        cancel_comment: Motivo do cancelamento
+        classification_name: Classificação
+        modality: Modalidade
+        draw_end_days: Dias corridos para desempate
 
         statuses:
           all: -- Listar Todas --
@@ -39,6 +43,11 @@ pt-BR:
           global: Preço global
           lot: Preço por lote
           unitary: Preço individual
+
+        modalities:
+          unrestricted: Aberta/Pública
+          open_invite: Convite aberto
+          closed_invite: Convite fechado
 
       errors:
         covenant:

--- a/src/config/locales/views/covenants/bidding.en-US.yml
+++ b/src/config/locales/views/covenants/bidding.en-US.yml
@@ -34,6 +34,7 @@
           start: Start procurement process
           review: Submit to revision
           draw: Break tie and submit to revision
+          regenerate_failure_bidding_minute: Generate minutes again
 
         cancelOverlay:
           title: Cancel procurement process

--- a/src/config/locales/views/covenants/bidding.es-PY.yml
+++ b/src/config/locales/views/covenants/bidding.es-PY.yml
@@ -34,6 +34,7 @@
           start: Iniciar licitación
           review: Enviar para revisión
           draw: Desempatar e enviar para revisión
+          regenerate_failure_bidding_minute: Volver a generar acta
 
         cancelOverlay:
           title: Cancelar licitación

--- a/src/config/locales/views/covenants/bidding.fr-FR.yml
+++ b/src/config/locales/views/covenants/bidding.fr-FR.yml
@@ -35,6 +35,7 @@
           review: Envoyer pour révision
           draw: Départager et envoyer pour révision
           failure: Echouer l'appel d'offres
+          regenerate_failure_bidding_minute: générer à nouveau des ATA
 
         cancelOverlay:
           title: Annuler l'appel d'offres

--- a/src/config/locales/views/covenants/bidding.pt-BR.yml
+++ b/src/config/locales/views/covenants/bidding.pt-BR.yml
@@ -35,6 +35,7 @@ pt-BR:
           review: Enviar para revisão
           draw: Desempatar e enviar para revisão
           failure: Fracassar licitação
+          regenerate_failure_bidding_minute: Gerar ata novamente
 
         cancelOverlay:
           title: Cancelar Licitação

--- a/src/config/locales/views/covenants/biddings/lots/proposal.en-US.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.en-US.yml
@@ -8,7 +8,9 @@
             empty: No proposal
             loading: Loading proposals...
             item_details: Detailing
-
+            attachments: Attachments
+            no_attachments: There are no attachments
+            
             proposal:
               status: 'Proposal %{status}'
               value: Proposal value

--- a/src/config/locales/views/covenants/biddings/lots/proposal.en-US.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.en-US.yml
@@ -7,6 +7,7 @@
             title: Procurement Processes
             empty: No proposal
             loading: Loading proposals...
+            item_details: Detailing
 
             proposal:
               status: 'Proposal %{status}'
@@ -19,6 +20,7 @@
               confirmRefuse: Confirm rejection
               reproveProposal: Reject proposal
               confirmAccept: Approve proposal
+              item_details: Item details
 
             cancelRefuseOverlay:
               title: Cancel rejection

--- a/src/config/locales/views/covenants/biddings/lots/proposal.es-PY.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.es-PY.yml
@@ -8,6 +8,8 @@
             empty: Ninguna propuesta
             loading: Cargando propuestas...
             item_details: Detallando
+            attachments: archivos adjuntos
+            no_attachments: No hay archivos adjuntos
 
             proposal:
               status: 'Propuesta %{status}'

--- a/src/config/locales/views/covenants/biddings/lots/proposal.es-PY.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.es-PY.yml
@@ -7,6 +7,7 @@
             title: Licitaciones
             empty: Ninguna propuesta
             loading: Cargando propuestas...
+            item_details: Detallando
 
             proposal:
               status: 'Propuesta %{status}'
@@ -19,6 +20,7 @@
               confirmRefuse: Confirmar rechazo
               reproveProposal: Reprobar propuesta
               confirmAccept: Aprobar propuesta
+              item_details: Detalles del artículo
 
             cancelRefuseOverlay:
               title: Cancelar rechazo

--- a/src/config/locales/views/covenants/biddings/lots/proposal.fr-FR.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.fr-FR.yml
@@ -7,6 +7,7 @@
             title: Appels d'offres
             empty: Aucune offre
             loading: Téléchargement des offres...
+            item_details: Détails
 
             proposal:
               status: 'Offre %{status}'
@@ -19,6 +20,7 @@
               confirmRefuse: Confirmer le rejet
               reproveProposal: Rejeter l'Offre
               confirmAccept: Approuver l'Offre
+              item_details: Détails de l'article
 
             cancelRefuseOverlay:
               title: Annuler le rejet

--- a/src/config/locales/views/covenants/biddings/lots/proposal.fr-FR.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.fr-FR.yml
@@ -8,6 +8,8 @@
             empty: Aucune offre
             loading: Téléchargement des offres...
             item_details: Détails
+            attachments: pièces jointes
+            no_attachments: il n'y a pas de pièces jointes
 
             proposal:
               status: 'Offre %{status}'

--- a/src/config/locales/views/covenants/biddings/lots/proposal.pt-BR.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.pt-BR.yml
@@ -7,11 +7,13 @@ pt-BR:
             title: Licitações
             empty: Nenhuma proposta
             loading: Carregando propostas...
+            item_details: Detalhamento
 
             proposal:
               status: 'Proposta %{status}'
               value: Valor da proposta
               total: 'Valor total:'
+              estimated_cost_total: 'Valor estimado:'
               refuse: 'Motivo da recusa:'
 
             button:
@@ -19,6 +21,7 @@ pt-BR:
               confirmRefuse: Confirmar recusa
               reproveProposal: Reprovar proposta
               confirmAccept: Aprovar proposta
+              item_details: Detalhes do item
 
             cancelRefuseOverlay:
               title: Cancelar recusa

--- a/src/config/locales/views/covenants/biddings/lots/proposal.pt-BR.yml
+++ b/src/config/locales/views/covenants/biddings/lots/proposal.pt-BR.yml
@@ -8,6 +8,8 @@ pt-BR:
             empty: Nenhuma proposta
             loading: Carregando propostas...
             item_details: Detalhamento
+            attachments: Anexos
+            no_attachments: Não há anexos
 
             proposal:
               status: 'Proposta %{status}'

--- a/src/config/locales/views/covenants/biddings/proposal.en-US.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.en-US.yml
@@ -7,6 +7,8 @@
           empty: No proposal
           loading: Loading proposals...
           item_details: Detailing
+          attachments: Attachments
+          no_attachments: There are no attachments
 
           proposal:
             status: 'Proposal %{status}'

--- a/src/config/locales/views/covenants/biddings/proposal.en-US.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.en-US.yml
@@ -6,6 +6,7 @@
           title: Procurement Processes
           empty: No proposal
           loading: Loading proposals...
+          item_details: Detailing
 
           proposal:
             status: 'Proposal %{status}'
@@ -20,6 +21,7 @@
             confirmRefuse: Confirm rejection
             reproveProposal: Reject proposal
             confirmAccept: Approve proposal
+            item_details: Item details
 
           cancelRefuseOverlay:
             title: Cancel rejection

--- a/src/config/locales/views/covenants/biddings/proposal.es-PY.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.es-PY.yml
@@ -6,6 +6,7 @@
           title: Licitaciones
           empty: Ninguna propuesta
           loading: Cargando propuestas...
+          item_details: Detallando
 
           proposal:
             status: 'Propuesta %{status}'
@@ -20,6 +21,7 @@
             confirmRefuse: Confirmar rechazo
             reproveProposal: Reprobar propuesta
             confirmAccept: Aprobar propuesta
+            item_details: Detalles del artículo
 
           cancelRefuseOverlay:
             title: Cancelar rechazo

--- a/src/config/locales/views/covenants/biddings/proposal.es-PY.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.es-PY.yml
@@ -7,7 +7,9 @@
           empty: Ninguna propuesta
           loading: Cargando propuestas...
           item_details: Detallando
-
+          attachments: archivos adjuntos
+          no_attachments: No hay archivos adjuntos
+          
           proposal:
             status: 'Propuesta %{status}'
             value: Valor de la propuesta

--- a/src/config/locales/views/covenants/biddings/proposal.fr-FR.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.fr-FR.yml
@@ -7,7 +7,9 @@
           empty: Aucune offre
           loading: Téléchargement des offres...
           item_details: Détails
-
+          attachments: pièces jointes
+          no_attachments: il n'y a pas de pièces jointes
+          
           proposal:
             status: 'Offre %{status}'
             value: Valeur de l'offre

--- a/src/config/locales/views/covenants/biddings/proposal.fr-FR.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.fr-FR.yml
@@ -6,6 +6,7 @@
           title: Appels d'offres
           empty: Aucune offre
           loading: Téléchargement des offres...
+          item_details: Détails
 
           proposal:
             status: 'Offre %{status}'
@@ -20,6 +21,7 @@
             confirmRefuse: Confirmer le rejet
             reproveProposal: Rejeter l'Offre
             confirmAccept: Approuver l'Offre
+            item_details: Détails de l'article
 
           cancelRefuseOverlay:
             title: Annuler le rejet

--- a/src/config/locales/views/covenants/biddings/proposal.pt-BR.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.pt-BR.yml
@@ -6,11 +6,13 @@ pt-BR:
           title: Licitações
           empty: Nenhuma proposta
           loading: Carregando propostas...
+          item_details: Detalhamento
 
           proposal:
             status: 'Proposta %{status}'
             value: Valor da proposta
             total: 'Valor total:'
+            estimated_cost_total: 'Valor estimado:'
             refuse: 'Motivo da recusa:'
 
           lot: 'Lote: %{value}'
@@ -20,6 +22,7 @@ pt-BR:
             confirmRefuse: Confirmar recusa
             reproveProposal: Reprovar proposta
             confirmAccept: Aprovar proposta
+            item_details: Detalhes do item
 
           cancelRefuseOverlay:
             title: Cancelar recusa

--- a/src/config/locales/views/covenants/biddings/proposal.pt-BR.yml
+++ b/src/config/locales/views/covenants/biddings/proposal.pt-BR.yml
@@ -7,6 +7,8 @@ pt-BR:
           empty: Nenhuma proposta
           loading: Carregando propostas...
           item_details: Detalhamento
+          attachments: Anexos
+          no_attachments: Não há anexos
 
           proposal:
             status: 'Proposta %{status}'

--- a/src/views/biddings/index.vue
+++ b/src/views/biddings/index.vue
@@ -78,6 +78,25 @@
               .admin-role {{ bidding.admin_name }}
 
             .row.mb-1
+              label {{ $t('models.bidding.attributes.startDate') }}
+              span
+                | {{ $l('date.formats.default', bidding.start_date) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.closingDate') }}
+              span
+                | {{ $l('date.formats.default', bidding.closing_date) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.modality') }}
+              span
+                | {{ $t('models.bidding.attributes.modalities.' + bidding.modality) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.classification_name') }}
+              span {{ bidding.classification_name }}
+
+            .row.mb-1
               label {{ $t('models.bidding.attributes.status') }}
               span.badge(:class="bidding.status")
                 | {{ $t('models.bidding.attributes.statuses.' + bidding.status) }}

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -6,6 +6,18 @@
     bottom: 0;
   }
 
+  #view {
+    .button.button-primary:disabled {
+      background-color: $pale-grey;
+      color: $black;
+  
+      &:hover {
+        background-color: $pale-grey;
+        color: $black;
+      }
+    }
+  }
+
  .badge {
     &.draft,
     &.closed,
@@ -73,6 +85,17 @@
               label {{ $t('models.bidding.attributes.status') }}
               span.badge(:class="bidding.status")
                 | {{ $t('models.bidding.attributes.statuses.' + bidding.status) }}
+
+            .row.mb-1(v-if="bidding.status === 'canceled'")
+              label {{ $t('models.bidding.attributes.cancel_comment') }}
+              span
+                | {{ bidding.cancel_comment }}
+
+            template(v-if="bidding.status == 'failure' && $ability.canManage('Bidding')")
+              .row.mb-1
+                .four.columns
+                  button.button.button-primary.u-full-width(@click="regenerateFailureBiddingMinute(bidding)", :disabled="regenerateFailureBiddingMinuteDisabled")
+                    | {{ $t('.button.regenerate_failure_bidding_minute') }}
 
           .four.columns
             h5.mb-0 {{ this.$t('.actions.title') }}
@@ -203,7 +226,8 @@
 
         cancelOverlayItem: null,
         showCancelOverlay: false,
-        showRefuseOverlay: false
+        showRefuseOverlay: false,
+        regenerateFailureBiddingMinuteFlag: false
       }
     },
 
@@ -215,6 +239,10 @@
       biddingNotOngoingOrDraw() {
         let status = this.bidding.status
         return status != "ongoing" && status != "draw"
+      },
+
+      regenerateFailureBiddingMinuteDisabled() {
+        return this.regenerateFailureBiddingMinuteFlag == true
       },
 
       biddingAtaPath() {
@@ -252,6 +280,12 @@
             this.error = _err
             console.error(_err)
           })
+      },
+
+      regenerateFailureBiddingMinute(bidding) {
+        this.regenerateFailureBiddingMinuteFlag = true
+
+        return this.$http.patch('/administrator/biddings/' + bidding.id + '/regenerate_failure_minutes')
       },
 
       approveBidding(bidding) {

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -6,6 +6,18 @@
     bottom: 0;
   }
 
+  #view {
+    .button.button-primary:disabled {
+      background-color: $pale-grey;
+      color: $black;
+  
+      &:hover {
+        background-color: $pale-grey;
+        color: $black;
+      }
+    }
+  }
+
  .badge {
     &.draft,
     &.closed,
@@ -73,6 +85,44 @@
               label {{ $t('models.bidding.attributes.status') }}
               span.badge(:class="bidding.status")
                 | {{ $t('models.bidding.attributes.statuses.' + bidding.status) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.classification_name') }}
+              span {{ bidding.classification_name }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.startDate') }}
+              span
+                | {{ $l('date.formats.default', bidding.start_date) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.closingDate') }}
+              span
+                | {{ $l('date.formats.default', bidding.closing_date) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.address') }}
+              span {{ bidding.address || $t('messages.not_informed') }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.draw_end_days') }}
+              span {{ bidding.draw_end_days }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.modality') }}
+              span
+                | {{ $t('models.bidding.attributes.modalities.' + bidding.modality) }}
+
+            .row.mb-1(v-if="bidding.status === 'canceled'")
+              label {{ $t('models.bidding.attributes.cancel_comment') }}
+              span
+                | {{ bidding.cancel_comment }}
+
+            template(v-if="bidding.status == 'failure' && $ability.canManage('Bidding')")
+              .row.mb-1
+                .four.columns
+                  button.button.button-primary.u-full-width(@click="regenerateFailureBiddingMinute(bidding)", :disabled="regenerateFailureBiddingMinuteDisabled")
+                    | {{ $t('.button.regenerate_failure_bidding_minute') }}
 
           .four.columns
             h5.mb-0 {{ this.$t('.actions.title') }}
@@ -203,7 +253,8 @@
 
         cancelOverlayItem: null,
         showCancelOverlay: false,
-        showRefuseOverlay: false
+        showRefuseOverlay: false,
+        regenerateFailureBiddingMinuteFlag: false
       }
     },
 
@@ -215,6 +266,10 @@
       biddingNotOngoingOrDraw() {
         let status = this.bidding.status
         return status != "ongoing" && status != "draw"
+      },
+
+      regenerateFailureBiddingMinuteDisabled() {
+        return this.regenerateFailureBiddingMinuteFlag == true
       },
 
       biddingAtaPath() {
@@ -252,6 +307,12 @@
             this.error = _err
             console.error(_err)
           })
+      },
+
+      regenerateFailureBiddingMinute(bidding) {
+        this.regenerateFailureBiddingMinuteFlag = true
+
+        return this.$http.patch('/administrator/biddings/' + bidding.id + '/regenerate_failure_minutes')
       },
 
       approveBidding(bidding) {

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -6,6 +6,18 @@
     bottom: 0;
   }
 
+  #view {
+    .button.button-primary:disabled {
+      background-color: $pale-grey;
+      color: $black;
+  
+      &:hover {
+        background-color: $pale-grey;
+        color: $black;
+      }
+    }
+  }
+
  .badge {
     &.draft,
     &.closed,
@@ -78,6 +90,12 @@
               label {{ $t('models.bidding.attributes.cancel_comment') }}
               span
                 | {{ bidding.cancel_comment }}
+
+            template(v-if="bidding.status == 'failure' && $ability.canManage('Bidding')")
+              .row.mb-1
+                .four.columns
+                  button.button.button-primary.u-full-width(@click="regenerateFailureBiddingMinute(bidding)", :disabled="regenerateFailureBiddingMinuteDisabled")
+                    | {{ $t('.button.regenerate_failure_bidding_minute') }}
 
           .four.columns
             h5.mb-0 {{ this.$t('.actions.title') }}
@@ -208,7 +226,8 @@
 
         cancelOverlayItem: null,
         showCancelOverlay: false,
-        showRefuseOverlay: false
+        showRefuseOverlay: false,
+        regenerateFailureBiddingMinuteFlag: false
       }
     },
 
@@ -220,6 +239,10 @@
       biddingNotOngoingOrDraw() {
         let status = this.bidding.status
         return status != "ongoing" && status != "draw"
+      },
+
+      regenerateFailureBiddingMinuteDisabled() {
+        return this.regenerateFailureBiddingMinuteFlag == true
       },
 
       biddingAtaPath() {
@@ -257,6 +280,12 @@
             this.error = _err
             console.error(_err)
           })
+      },
+
+      regenerateFailureBiddingMinute(bidding) {
+        this.regenerateFailureBiddingMinuteFlag = true
+
+        return this.$http.patch('/administrator/biddings/' + bidding.id + '/regenerate_failure_minutes')
       },
 
       approveBidding(bidding) {

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -74,6 +74,11 @@
               span.badge(:class="bidding.status")
                 | {{ $t('models.bidding.attributes.statuses.' + bidding.status) }}
 
+            .row.mb-1(v-if="bidding.status === 'canceled'")
+              label {{ $t('models.bidding.attributes.cancel_comment') }}
+              span
+                | {{ bidding.cancel_comment }}
+
           .four.columns
             h5.mb-0 {{ this.$t('.actions.title') }}
             hr.mt-0

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -86,6 +86,33 @@
               span.badge(:class="bidding.status")
                 | {{ $t('models.bidding.attributes.statuses.' + bidding.status) }}
 
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.classification_name') }}
+              span {{ bidding.classification_name }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.startDate') }}
+              span
+                | {{ $l('date.formats.default', bidding.start_date) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.closingDate') }}
+              span
+                | {{ $l('date.formats.default', bidding.closing_date) }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.address') }}
+              span {{ bidding.address }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.draw_end_days') }}
+              span {{ bidding.draw_end_days }}
+
+            .row.mb-1
+              label {{ $t('models.bidding.attributes.modality') }}
+              span
+                | {{ $t('models.bidding.attributes.modalities.' + bidding.modality) }}
+
             .row.mb-1(v-if="bidding.status === 'canceled'")
               label {{ $t('models.bidding.attributes.cancel_comment') }}
               span

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -91,6 +91,12 @@
               span {{ bidding.classification_name }}
 
             .row.mb-1
+              label {{ $t('models.bidding.attributes.subclassifications') }}
+              span(v-if="bidding.subclassifications.length === 0") {{ $t('messages.not_informed') }}
+              .row(v-for="subclassification in bidding.subclassifications")
+                span {{ subclassification.name }}
+
+            .row.mb-1
               label {{ $t('models.bidding.attributes.startDate') }}
               span
                 | {{ $l('date.formats.default', bidding.start_date) }}

--- a/src/views/biddings/show.vue
+++ b/src/views/biddings/show.vue
@@ -102,7 +102,7 @@
 
             .row.mb-1
               label {{ $t('models.bidding.attributes.address') }}
-              span {{ bidding.address }}
+              span {{ bidding.address || $t('messages.not_informed') }}
 
             .row.mb-1
               label {{ $t('models.bidding.attributes.draw_end_days') }}

--- a/src/views/covenants/biddings/lots/proposals/index.vue
+++ b/src/views/covenants/biddings/lots/proposals/index.vue
@@ -101,7 +101,11 @@
             strong {{ $t('.proposal.refuse') }}
             |  {{ proposal.comment }}
 
-        table-list
+        span {{ $t('.proposal.estimated_cost_total') }}
+        span.ml-1.price-total
+          |  {{ $asCurrency(proposal.lot.estimated_cost_total) }}
+
+        table-list.mt-1
           thead
             tr
               th
@@ -112,19 +116,27 @@
 
               th
                 | {{ $t('models.lot_group_item_lot_proposal.attributes.price') }}
+                
+              th
+                | {{ $t('.item_details') }}
+
 
           tbody(v-if="proposal.lot_group_item_lot_proposals")
             tr(v-for="lot_group_item_lot_proposal in proposal.lot_group_item_lot_proposals")
               td(width="50%")
                 | {{ lot_group_item_lot_proposal.lot_group_item.item_short_name }}
 
-              td(width="20%")
+              td(width="10%")
                 | {{ $asNumber(lot_group_item_lot_proposal.lot_group_item.quantity, { precision: 2 }) }}
 
-              td(width="30%")
+              td(width="20%")
                 |  {{ $asCurrency(lot_group_item_lot_proposal.price) }}
 
                 |  / {{ lot_group_item_lot_proposal.lot_group_item.item_unit }}
+
+              td(width="20%")
+                router-link.button.router-link(:to="{ name: 'item', params: { id: lot_group_item_lot_proposal.lot_group_item.item_id } }")
+                  | {{ $t('.button.item_details') }}
 
         .row(v-if="proposal.status == 'coop_refused'")
           .button.button-danger.button-cancel-refuse-proposal(@click="toggleCancelRefuseOverlay(proposal)")

--- a/src/views/covenants/biddings/lots/proposals/index.vue
+++ b/src/views/covenants/biddings/lots/proposals/index.vue
@@ -90,6 +90,18 @@
             label {{ $t('models.legal_representative.attributes.cpf') }}
             span {{ proposal.provider.legal_representative.cpf }}
 
+        h6.mt-1.mb-1 {{ $t('.attachments') }}
+
+        .row(v-for="(lotAttachment, key) in proposal.lot_attachments")
+          .twelve.columns
+            a.input-file.mb-1(:href="attachmentPath(lotAttachment.attachment_file)", target="_blank")
+              i.fa.fa-download.mr-1.u-pull-left
+              span.attachment-name {{ lotAttachment.attachment_filename }}
+
+        .row(v-if="proposal.lot_attachments.length === 0")
+          .twelve.columns
+            span {{ $t('.no_attachments') }}
+
         h6.mt-1.mb-1 {{ $t('.proposal.value') }}
 
         .price-container.mb-2(:class="proposal.status")
@@ -271,6 +283,11 @@
             this.error = _err
             console.error(_err)
           })
+      },
+
+      attachmentPath(attachment) {
+        if(typeof attachment === 'undefined') return
+        return app.secrets.api.host + attachment.url
       },
 
       toggleCancelRefuseOverlay(proposal) {

--- a/src/views/covenants/biddings/proposals/index.vue
+++ b/src/views/covenants/biddings/proposals/index.vue
@@ -107,7 +107,11 @@
         div(v-for="lot_proposal in proposal.lot_proposals")
           h6 {{ $t('.lot', { value: lot_proposal.lot.name }) }}
 
-          table-list
+          span {{ $t('.proposal.estimated_cost_total') }}
+          span.ml-1.price-total
+            |  {{ $asCurrency(lot_proposal.lot.estimated_cost_total) }}
+
+          table-list.mt-1
             thead
               tr
                 th
@@ -119,17 +123,24 @@
                 th
                   | {{ $t('models.lot_group_item_lot_proposal.attributes.price') }}
 
+                th
+                  | {{ $t('.item_details') }}
+
             tbody(v-if="lot_proposal.lot_group_item_lot_proposals")
               tr(v-for="lot_group_item_lot_proposal in lot_proposal.lot_group_item_lot_proposals")
                 td(width="50%")
                   | {{ lot_group_item_lot_proposal.lot_group_item.item_short_name }}
 
-                td(width="20%")
+                td(width="10%")
                   | {{ $asNumber(lot_group_item_lot_proposal.lot_group_item.quantity, { precision: 2 }) }}
 
-                td(width="30%")
+                td(width="20%")
                   |  {{ $asCurrency(lot_group_item_lot_proposal.price) }}
                   |  / {{ lot_group_item_lot_proposal.lot_group_item.item_unit }}
+
+                td(width="20%")
+                  router-link.button.router-link(:to="{ name: 'item', params: { id: lot_group_item_lot_proposal.lot_group_item.item_id } }")
+                    | {{ $t('.button.item_details') }}
 
         .row(v-if="proposal.status == 'coop_refused'")
           .button.button-danger(@click="toggleCancelRefuseOverlay(proposal)")

--- a/src/views/covenants/biddings/proposals/index.vue
+++ b/src/views/covenants/biddings/proposals/index.vue
@@ -90,6 +90,20 @@
             label {{ $t('models.legal_representative.attributes.cpf') }}
             span {{ proposal.provider.legal_representative.cpf }}
 
+        h6.mt-1.mb-1 {{ $t('.attachments') }}
+
+        .row(v-for="(lotProposal, key) in proposal.lot_proposals")
+
+          .row(v-for="(lotAttachment, key_teste) in lotProposal.lot_attachments")
+            .twelve.columns
+              a.input-file.mb-1(:href="attachmentPath(lotAttachment.attachment_file)", target="_blank")
+                i.fa.fa-download.mr-1.u-pull-left
+                span.attachment-name {{ lotAttachment.attachment_filename }}
+
+          .row(v-if="lotProposal.lot_attachments.length === 0")
+            .twelve.columns
+              span {{ $t('.no_attachments') }}
+
         hr
         h6.mt-1.mb-1 {{ $t('.proposal.value') }}
 
@@ -269,6 +283,11 @@
             this.error = _err
             console.error(_err)
           })
+      },
+
+      attachmentPath(attachment) {
+        if(typeof attachment === 'undefined') return
+        return app.secrets.api.host + attachment.url
       },
 
       toggleCancelRefuseOverlay(proposal) {


### PR DESCRIPTION
Tarefas:

- [Item 31] [FORNECEDOR] Adição de adendo para fluxo de contrato não assinado
  - Tarefa substitui o item 24 (Poder aditivar o prazo de entrega)
  - No sistema, é preciso adicionar adendo na ata quando o Fornecedor não assinar o contrato dentro do prazo de cinco dias.
  - No sistema, também é necessário adicionar adendo quando outra proposta for selecionada como vencedora após um Fornecedor não assinar o contrato dentro de um prazo de cinco dias.

- [Item 16] Ajustar o envio de notificações para o Fornecedor de acordo com a categoria cadastrada
  - Como fornecedor, quero receber as notificações do SOL apenas para as categorias que me cadastrei. Reduzindo assim, a quantidade de mensagens indesejadas.

- [Item 20] Criar uma rotina para gerar a Ata (Módulo Revisor e APP da Associação)
  - Para cancelamento de licitação, NÃO tem que ter geração de ata. Tem que existir apenas o "motivo" (dados gerais da licitação, localizado abaixo de "situação" na licitação. Inserir a descrição de "motivo".
  - O REVISOR também necessita ver o "motivo" na tela. Dessa forma, ambos os usuários (ADMINISTRADOR e REVISOR) têm acesso.
  - Quando a licitação estiver fracassada, já aparece o botão de ata. Fica a cargo do ADMINISTRADOR depois, verificar e caso seja necessário, gerar novamente essa ata.

- [Item 28 NOVO] Confirmar as informações que serão adicionadas no card da licitação no módulo de Administrador
  - Exibir os campos na página de detalhes de uma licitação:
    - Quais foram as datas (abertura e encerramento)
    - Modalidade (aberta, convite aberta, convite fechado)
    - Classificação (Bens, Obras, Serviços)

- [Item 26] Permitir que apareça o detalhamento dos itens para o REVISOR quando a licitação for criada (status: aguardando liberação)
  - Tem que existir um detalhamento maior e melhor do item licitado: início, data de encerramento, tipo de modalidade etc. Em suma, é replicar a primeira tela que temos do usuário ASSOCIAÇÃO para essa que será incrementada.
  - Isso será disponibilizado para os usuários ADMINISTRADOR e REVISOR.

- [Item 14] Exibir licitações em rascunhos que utilizem os itens
  - Ao clicar em um novo item dentro de um lote ao criar uma licitação, deve-se exibir para cada item, quais são as licitações em rascunho que o estão utilizando;
  - Precisa chamar a atenção do usuário para os rascunhos que estão utilizando os itens.

- [Item 22 NOVO] [REVISOR] Detalhamento por itens e preços
  - como Revisor, ao acessar os lotes de uma licitação, gostaria que fossem exibidos o valor estimado do lote e para cada linha da tabela presente nessa página, exibir o valor do item e o botão que irá exibir o detalhamento total desse item (todos os atributos do item)

- [Item 6] Remover a limitação de visualização dos itens na planilha
  - É necessária uma paginação melhor para visualização dos itens. Verificar o botão de "adicionar grupo" na tela de adição de lotes no usuário.

- [Item 29 NOVO] Inserção de botão "Adicionar Grupo" no módulo de ASSOCIAÇÃO
  - Existia uma tarefa antiga do Ciclo I, que era justamente incluir o botão de "Adicionar Grupo" na parte de LOTES (módulo: ASSOCIAÇÃO). Nas últimas atualizações, esse botão deixou de aparecer no sistema do SOL.

- [Item 11] Incluir espaço para upload de documentos pelo Fornecedor de melhor proposta
  1 - Como Fornecedor, muitas vezes é necessário incluir diversos arquivos como certidões e documentos de qualificação técnica. A Associação tem que visualizar essa documentação pelo lote, ou seja, o Fornecedor pode ter vencido vários lotes e quando for enviado esse documento, é necessário que apareça tudo de uma vez (todos os lotes vencedores). Exemplo: tendo cinco lotes e vencido três, esses três precisam aparecer para os lotes vencedores.
  Para o Fornecedor vencedor, existirá uma notificação informando que pode ocorrer a inserção dos documentos;

  2 - Para adicionar arquivos no sistema, é preciso abrir a licitação na primeira tela no módulo do Fornecedor. Assim como temos o campo de cadastrar a proposta, pode-se inserir esse campo ao lado do já existente (“criar proposta”). O nome desse campo será “inserir documentos”; sendo obrigatória a inserção;

  3 - Após isso, temos o envio de notificação e liberação do espaço para envio dos documentos. Nesse ponto, terá notificação para a Associação, após os documentos forem anexados;

  4 - Como Associação, gostaria de visualizar os documentos enviados pelo Fornecedor e receber a notificação. Esses documentos deverão ser visualizados por lote (tem que estar vinculado a ele, porque a licitação pode ter vários lotes). Mesmo com a recusa de um Fornecedor, deverá ser mantido o histórico dos documentos enviados por todos os Fornecedores;

  5 - O momento para envio da notificação, é quando o sistema define o vencedor, antes da aprovação/recusa da Associação;

  6 – Como Associação, Administrador e Revisor, não posso fazer nenhuma alteração de documentação. Isso quer dizer que não posso excluir, adicionar ou alterar esses documentos, somente visualizar na própria licitação;

  7 – Como Fornecedor, preciso de 5 dias corridos para envio dos documentos. Caso o Fornecedor não envie dentro desse prazo, fica a cargo da Associação aprovar ou reprovar a proposta.
  Caso o Fornecedor envie os documentos e a Associação ao analisá-los verifica que falta alguma documentação, poderá preencher um texto e clicar em um botão informando que o Fornecedor precisa completar essa documentação. O prazo é de 2 dias corridos para o Fornecedor ajustar a documentação e efetuar o envio.
  Toda ação de envio de documentação pelo Fornecedor ou solicitação pela Associação, gera notificação.
  Quando o sistema identificar a proposta de menor valor, deve-se enviar notificação ao Fornecedor associado a proposta.
  Tanto Administrador, quanto o Revisor precisam visualizar os documentos, o Administrador na show de uma licitação e o Revisor na hora da aprovação.
  Deve-se manter o histórico dos documentos enviados pelos Fornecedores. Não se pode apagar essas informações;

  8 - Como Revisor, necessito analisar a documentação enviada pelos Fornecedores, para evitar alguma fraude ou movimento ilegal por parte da Associação. Isso se dá para ver se a Associação foi coerente e recusou por algum motivo pertinente.


- [Item 30] [FORNECEDOR] Atualização Cadastral
  - Substitui o item 7 (Exibir a Ata imediatamente ao finalizar licitação)
  - Como Fornecedor, não consigo fazer nenhum tipo de alteração no cadastro. O tipo de atualização seria de telefone, categoria que a empresa atende etc.
